### PR TITLE
ci: 更新 npm 发布工作流以支持自动发布

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,8 +1,6 @@
-# This workflow will run tests using node and then publish a package to GitHub Packages when a release is created
-# For more information see: https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages
-
-name: Node.js Package
-
+# 当具有 publish 标签的 PR 被合并时，自动发布新版本
+# Automatically publish a new version when a PR with the publish label is merged
+name: Auto Publish
 on:
   pull_request:
     types: [closed]
@@ -10,26 +8,29 @@ on:
       - v*
 
 jobs:
-  build:
+  publish:
     runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-      - run: npm run ci
-      - run: npm run test
+    if: contains(github.event.pull_request.labels.*.name, 'publish') && github.event.pull_request.merged == true
 
-  publish-npm:
-    needs: build
-    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+
+      - name: Install Node.js
+        uses: actions/setup-node@v4
         with:
           node-version: 20
-          registry-url: https://registry.npmjs.org/
-      - run: npm ci
-      - run: npm publish
+
+      - name: Install pnpm and dependencies
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+          run_install: true
+
+      - name: Build
+        run: pnpm run build
+
+      - name: Publish
         env:
-          NODE_AUTH_TOKEN: ${{secrets.npm_token}}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: pnpm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN} & pnpm run publish


### PR DESCRIPTION
修改 GitHub Actions 工作流，当带有 publish 标签的 PR 合并时自动发布新版本 使用 pnpm 替代 npm 并优化发布流程